### PR TITLE
Simplify description from pydantic.FieldInfo by adding a help field to cyclopts.FieldInfo.

### DIFF
--- a/cyclopts/argument.py
+++ b/cyclopts/argument.py
@@ -190,7 +190,7 @@ class ArgumentCollection(list["Argument"]):
         cls,
         field_info: FieldInfo,
         keys: tuple[str, ...],
-        *default_parameters,
+        *default_parameters: Optional[Parameter],
         group_lookup: dict[str, Group],
         group_arguments: Group,
         group_parameters: Group,
@@ -314,7 +314,9 @@ class ArgumentCollection(list["Argument"]):
                     sub_field_info,
                     keys + (sub_field_name,),
                     cparam,
-                    hint_docstring_lookup.get((sub_field_name,)),
+                    Parameter(help=sub_field_info.help)
+                    if sub_field_info.help
+                    else hint_docstring_lookup.get((sub_field_name,)),
                     Parameter(required=argument.required & sub_field_info.required),
                     group_lookup=group_lookup,
                     group_arguments=group_arguments,
@@ -379,7 +381,7 @@ class ArgumentCollection(list["Argument"]):
                 field_info,
                 (),
                 *default_parameters,
-                docstring_lookup.get((field_info.name,)),
+                Parameter(help=field_info.help) if field_info.help else docstring_lookup.get((field_info.name,)),
                 group_lookup=group_lookup,
                 group_arguments=group_arguments,
                 group_parameters=group_parameters,


### PR DESCRIPTION
Basically, I added a `help` attribute to `cyclopts.FieldInfo` that gets precedence over help-from-docstrings. This keeps more logic out of pydantic-specific branches of code.

If this looks good and works in your use-cases, we can merge this into your branch, and then merge that branch into Cyclopts `main`. I'll then cut a release in a day or two (I want to investigate the blank-space-inhelp-page bug).

You can see a diff to `main` [here](https://github.com/BrianPugh/cyclopts/compare/pydantic.field.description.2?expand=1).